### PR TITLE
Make idealized_hurricane single CPU

### DIFF
--- a/exp_resources.py
+++ b/exp_resources.py
@@ -17,7 +17,7 @@ min_cpus = {
     'single_column/EPBL' : 1,
     'resting/z' : 8,
     'resting/layer' : 8,
-    'SCM_idealized_hurricane' : 4,
+    'SCM_idealized_hurricane' : 1,
     'CVmix_SCM_tests/mech_only/BML' : 1,
     'CVmix_SCM_tests/mech_only/KPP' : 1,
     'CVmix_SCM_tests/mech_only/EPBL' : 1,


### PR DESCRIPTION
This is another single column test that won't run correctly with symmetric memory on multiple processors.
